### PR TITLE
Add action inputs to install additional packages and run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 GitHub action for CMake based C++ project, that runs cppcheck and clang-tidy, and creates comment for PR with any issues found. Created comment will contain code snippets with the issue description. When this action is run for the first time, the comment with the initial result will be created for current Pull Request. Consecutive runs will edit this comment with updated status.
 
+
 Note that it's possible that the amount of issues detected can make the comment's body to be greater than the GitHub's character limit per PR comment (which is 65536). In that case, the created comment will contain only the isues found to that point and the information that the limit of characters was reached.
 
-In order for this action to work properly, your project has to be CMake based and also include ```.clang-tidy``` file in your root directory.
 
-The CPPCHECK will run with the following flags: </br>
+In order for this action to work properly, your project has to be CMake based and also include ```.clang-tidy``` file in your root directory. If your projects requires some additional packages to be installed, you can use `apt_pckgs` and/or `init_script` input variables to install them (see the **Workflow example** or **Inputs** sections below)
+
+
+The **CPPCHECK** will run with the following flags: </br>
 ```--enable=all --suppress=missingInclude --inline-suppr --inconclusive```
 
-and clang-tidy will look for the ```.clang-tidy``` file in your repository.
+**clang-tidy** will look for the ```.clang-tidy``` file in your repository.
 
 ## Workflow example
 
@@ -19,20 +22,40 @@ name: Static analysis
 on: [pull_request]
 
 jobs:
-  graph:
+  static analysis:
     runs-on: ubuntu-latest
+
     steps:
+    - uses: actions/checkout@v2
+
+    - name: setup init_script
+      shell: bash
+      run: |
+        echo "#!/bin/bash
+        add-apt-repository ppa:oibaf/graphics-drivers
+        apt update
+        apt upgrade
+        apt install -y libvulkan1 mesa-vulkan-drivers vulkan-utils" > init_script.sh
+
     - name: Run static analysis
       uses: JacobDomagala/StaticAnalysis@master
       with:
-        exclude_dir: dependencies
+        exclude_dir: lib
+        apt_pckgs: software-properties-common
+        init_script: init_script.sh
 ```
 
 ## Inputs
 
 | Name                    |Required| Description                        | Default value |
-|-------------------------|--------|------------------------------------|---------------|
-| `github_token`          | TRUE   | Github token used for Github API requests | ${{ github.token }} |
-| `pr_num`                | TRUE   | Pull request number for which the comment will be created | ${{ github.event.pull_request.number }} |
+|-------------------------|--------|------------------------------------|:---------------:|
+| `github_token`          | TRUE   | Github token used for Github API requests |`${{github.token}}`|
+| `pr_num`                | TRUE   | Pull request number for which the comment will be created |`${{github.event.pull_request.number}}`|
 | `comment_title`         | TRUE   | Title for comment with the raport. This should be an unique name | `Static analysis result` |
-| `exclude_dir`           | FALSE  | Directory which should be excluded from the raport | `empty` |
+| `exclude_dir`           | FALSE  | Directory which should be excluded from the raport | `<empty>` |
+| `apt_pckgs`             | FALSE  | Additional (comma separated) packages that need to be installed in order for project to compile | `<empty>` |
+| `init_script`           | FALSE  | Optional shell script that will be run before running CMake command. This should be used, when the project requires some environmental set-up beforehand. | `<empty>` |
+
+
+
+### **NOTE: `apt_pckgs` will run before `init_script`, just in case you need some packages installed before running the script**

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,11 @@ inputs:
     description: 'Directory which should be excluded from the raport'
   apt_pckgs:
     description: 'Additional (comma separated) packages that need to be installed in order for project to compile'
+  init_script:
+    description: |
+      'Optional shell script that will be run before running CMake command.'
+      'This should be used, when the project requires some environmental set-up beforehand'
+      'Note. `apt_pckgs` will run before this script, just in case you need some packages installed'
 
 runs:
   using: "docker"

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,8 @@ inputs:
     required: true
   exclude_dir:
     description: 'Directory which should be excluded from the raport'
+  apt_pckgs:
+    description: 'Additional (comma separated) packages that need to be installed in order for project to compile'
 
 runs:
   using: "docker"

--- a/docker/static_analysis.dockerfile
+++ b/docker/static_analysis.dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+
+ENV CXX=clang++
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y python3 python3-pip git xorg-dev\
+    build-essential clang-11 lldb-11 lld-11 libc++-11-dev cppcheck llvm-dev clang-tidy
+RUN pip3 install PyGithub
+
+RUN git clone https://github.com/Kitware/CMake.git && cd CMake && ./bootstrap && make && make install

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,16 +2,23 @@
 
 set -x
 
-cd "$GITHUB_WORKSPACE"
+if [ -n "$INPUT_APT_PCKGS" ]; then
+    for i in ${INPUT_APT_PCKGS//,/ }
+    do
+        apt-get install -y "$i"
+    done
+fi
 
-mkdir build && cd build
+cd "$GITHUB_WORKSPACE" || exit
+
+mkdir build && cd build || exit
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
 
 if [ -z "$INPUT_EXCLUDE_DIR" ]; then
     cppcheck src --enable=all --suppress=missingInclude --inline-suppr --inconclusive --output-file=cppcheck.txt --project=compile_commands.json
     run-clang-tidy >(tee "clang_tidy.txt")
 else
-    cppcheck src --enable=all --suppress=missingInclude --inline-suppr --inconclusive --output-file=cppcheck.txt --project=compile_commands.json -i$GITHUB_WORKSPACE/$INPUT_EXCLUDE_DIR
+    cppcheck src --enable=all --suppress=missingInclude --inline-suppr --inconclusive --output-file=cppcheck.txt --project=compile_commands.json -i"$GITHUB_WORKSPACE/$INPUT_EXCLUDE_DIR"
     run-clang-tidy "^((?!$GITHUB_WORKSPACE/$INPUT_EXCLUDE_DIR).)*$" > clang_tidy.txt
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,15 @@ set -x
 if [ -n "$INPUT_APT_PCKGS" ]; then
     for i in ${INPUT_APT_PCKGS//,/ }
     do
+        apt-get update
         apt-get install -y "$i"
     done
 fi
 
-cd "$GITHUB_WORKSPACE" || exit
+if [ -n "$INPUT_INIT_SCRIPT" ]; then
+    chmod +x "$INPUT_INIT_SCRIPT"
+    bash $INPUT_INIT_SCRIPT
+fi
 
 mkdir build && cd build || exit
 cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..


### PR DESCRIPTION
Adds two additional input variables:
- `apt_pckgs` -> Additional (comma separated) packages that need to be installed in order for project to compile
- `init_script` -> Optional shell script that will be run before running CMake command. This should be used, when the project requires some environmental set-up beforehand 

Note. `apt_pckgs` will run before `init_script`, just in case you need some packages installed before running the script