### PR TITLE
[#56]: Fix clang-tidy command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -82,6 +82,6 @@ fi
 
 # Excludes for clang-tidy are handled in python script
 debug_print "Running clang-tidy-15 $INPUT_CLANG_TIDY_ARGS -p $(pwd) $files_to_check >>clang_tidy.txt 2>&1"
-eval clang-tidy-14 "$INPUT_CLANG_TIDY_ARGS" -p "$(pwd)" "$files_to_check" >>clang_tidy.txt 2>&1 || true
+eval clang-tidy-15 "$INPUT_CLANG_TIDY_ARGS" -p "$(pwd)" "$files_to_check" >>clang_tidy.txt 2>&1 || true
 
 python3 /run_static_analysis.py -cc cppcheck.txt -ct clang_tidy.txt -o $print_to_console -fk $use_extra_directory


### PR DESCRIPTION
Fixes #56 