### PR TITLE
[#78]: Add `root_dir` and `build_dir` params to execution of `init_script`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,14 @@ jobs:
       shell: bash
       run: |
         echo "#!/bin/bash
+
+        # Input args provided by StaticAnalysis action
+        root_dir=\${1}
+        build_dir=\${2}
+        echo \"Hello from the init script! First arg=\${root_dir} second arg=\${build_dir}\"
+
         add-apt-repository ppa:oibaf/graphics-drivers
-        apt update
-        apt upgrade
+        apt update && apt upgrade
         apt install -y libvulkan1 mesa-vulkan-drivers vulkan-utils" > init_script.sh
 
     - name: Run static analysis
@@ -95,7 +100,7 @@ jobs:
 | `comment_title`         | FALSE  | Title for comment with the raport. This should be an unique name | `Static analysis result` |
 | `exclude_dir`           | FALSE  | Directory which should be excluded from the raport | `<empty>` |
 | `apt_pckgs`             | FALSE  | Additional (space separated) packages that need to be installed in order for project to compile | `<empty>` |
-| `init_script`           | FALSE  | Optional shell script that will be run before running CMake command. This should be used, when the project requires some environmental set-up beforehand. | `<empty>` |
+| `init_script`           | FALSE  | Optional shell script that will be run before configuring project (i.e. running CMake command). This should be used, when the project requires some environmental set-up beforehand. Script will be run with 2 arguments: `root_dir`(root directory of user's code) and `build_dir`(build directory created for running SA). Note. `apt_pckgs` will run before this script, just in case you need some packages installed. Also this script will be run in the root of the project (`root_dir`) | `<empty>` |
 | `cppcheck_args`         | FALSE  | Cppcheck (space separated) arguments that will be used |`--enable=all --suppress=missingInclude --inline-suppr --inconclusive`|
 | `clang_tidy_args`       | FALSE  | clang-tidy arguments that will be used (example: `-checks='*,fuchsia-*,google-*,zircon-*'` |`<empty>`|
 | `report_pr_changes_only`| FALSE  | Only post the issues found within the changes introduced in this Pull Request. This means that only the issues found within the changed lines will po posted. Any other issues caused by these changes in the repository, won't be reported, so in general you should run static analysis on entire code base  |`false`|

--- a/action.yml
+++ b/action.yml
@@ -28,8 +28,9 @@ inputs:
     description: |
       'Optional shell script that will be run before configuring project (i.e. running CMake command).'
       'This should be used, when the project requires some environmental set-up beforehand'
+      'Script will be run with 2 arguments: `root_dir`(root directory of user's code) and `build_dir`(build directory created for running SA)'
       'Note. `apt_pckgs` will run before this script, just in case you need some packages installed'
-      'Also this script will be run in the root of the project'
+      'Also this script will be run in the root of the project (`root_dir`)'
   cppcheck_args:
     description: 'cppcheck (space separated) arguments that will be used'
     default: --enable=all --suppress=missingInclude --inline-suppr --inconclusive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -59,7 +59,7 @@ mkdir -p build
 if [ -n "$INPUT_INIT_SCRIPT" ]; then
     chmod +x "$GITHUB_WORKSPACE/$INPUT_INIT_SCRIPT"
     # shellcheck source=/dev/null
-    source "$GITHUB_WORKSPACE/$INPUT_INIT_SCRIPT"
+    source "$GITHUB_WORKSPACE/$INPUT_INIT_SCRIPT" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build"
 fi
 
 cd build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ fi
 debug_print "Repo = ${INPUT_PR_REPO}  PR_HEAD = ${INPUT_PR_HEAD} event name = ${GITHUB_EVENT_NAME}"
 
 use_extra_directory=false
+original_root_dir="$GITHUB_WORKSPACE"
 
 # This is useful when running this Action from fork (together with [pull_request_target])
 if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ] && [ -n "$INPUT_PR_REPO" ]; then
@@ -57,9 +58,10 @@ debug_print "GITHUB_WORKSPACE = ${GITHUB_WORKSPACE} INPUT_EXCLUDE_DIR = ${INPUT_
 mkdir -p build
 
 if [ -n "$INPUT_INIT_SCRIPT" ]; then
-    chmod +x "$GITHUB_WORKSPACE/$INPUT_INIT_SCRIPT"
+    # Use $original_root_dir here, just in case we're running in pull_request_target
+    chmod +x "$original_root_dir/$INPUT_INIT_SCRIPT"
     # shellcheck source=/dev/null
-    source "$GITHUB_WORKSPACE/$INPUT_INIT_SCRIPT" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build"
+    source "$original_root_dir/$INPUT_INIT_SCRIPT" "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/build"
 fi
 
 cd build


### PR DESCRIPTION
Fixes #78 