### PR TITLE
clang 19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdomagala/static_analysis:latest
+FROM jhyry9docks/static_analysis:clang19
 
 WORKDIR /src
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Static analysis for C++/Python project"
+name: "Static analysis for C++ (Clang-19)/Python project"
 description: "Static analysis with cppcheck & clang-tidy for C++, pylint for Python. Posts results to PRs or console."
 
 inputs:

--- a/docker/static_analysis.dockerfile
+++ b/docker/static_analysis.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04 as base
+FROM ubuntu:24.04 as base
 
 # Define versions as environment variables
 ENV CLANG_VERSION=19 \

--- a/docker/static_analysis.dockerfile
+++ b/docker/static_analysis.dockerfile
@@ -1,40 +1,48 @@
-FROM ubuntu:24.04 as base
+FROM ubuntu:24.04 AS base
 
-# Define versions as environment variables
-ENV CLANG_VERSION=19 \
-    CPPCHECK_VERSION=2.14.0 \
-    CXX=clang++ \
-    CC=clang \
-    DEBIAN_FRONTEND=noninteractive
-
-# Copy the llvm.sh installation script
-COPY llvm.sh /llvm.sh
+ENV CLANG_VERSION=19
+ENV CPPCHECK_VERSION=2.14.0
+ENV CXX=clang++
+ENV CC=clang
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
-        build-essential python3 python3-pip git wget libssl-dev ninja-build \
-        lsb-release software-properties-common gnupg \
-    # Execute the LLVM install script with the version number
-    && chmod +x /llvm.sh && /llvm.sh $CLANG_VERSION \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Install Python packages
-    && pip3 install --break-system-packages PyGithub pylint \
-    # Create symlinks for clang and clang++
-    && ln -s "$(which clang++-$CLANG_VERSION)" /usr/bin/clang++ \
-    && ln -s "$(which clang-$CLANG_VERSION)" /usr/bin/clang \
-    && ln -s /usr/bin/python3 /usr/bin/python
+      build-essential python3 python3-pip \
+      git wget libssl-dev ninja-build gnupg \
+      lsb-release software-properties-common
 
+# Copy the llvm.sh installation script
+COPY --chmod=500 llvm.sh /opt/llvm/llvm.sh
+
+# Execute the LLVM install script with the version number
+WORKDIR /opt/llvm
+RUN ./llvm.sh $CLANG_VERSION
+
+# Clean up
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/*
+
+# Install Python packages
+RUN pip3 install --break-system-packages PyGithub pylint
+
+# Create symlinks for clang and clang++
+RUN ln -s "$(which clang++-$CLANG_VERSION)" /usr/bin/clang++
+RUN ln -s "$(which clang-$CLANG_VERSION)" /usr/bin/clang
+
+# Create a symlink for python
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Build and install CMake from source
 WORKDIR /opt
-
-# Build CMake from source
-RUN git clone https://github.com/Kitware/CMake.git \
-    && cd CMake \
-    && ./bootstrap && make -j$(nproc) && make install
+RUN git clone https://github.com/Kitware/CMake.git
+WORKDIR /opt/CMake
+RUN ./bootstrap && make -j$(nproc) && make install
 
 # Install cppcheck
-RUN git clone https://github.com/danmar/cppcheck.git \
-    && cd cppcheck \
-    && git checkout tags/$CPPCHECK_VERSION \
-    && mkdir build && cd build \
-    && cmake -G Ninja .. && ninja all && ninja install
+WORKDIR /opt
+RUN git clone https://github.com/danmar/cppcheck.git
+WORKDIR /opt/cppcheck
+RUN git checkout tags/$CPPCHECK_VERSION
+WORKDIR /opt/cppcheck/build
+RUN cmake -G Ninja .. && ninja all && ninja install

--- a/docker/static_analysis.dockerfile
+++ b/docker/static_analysis.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:23.04 as base
 
 # Define versions as environment variables
-ENV CLANG_VERSION=18 \
+ENV CLANG_VERSION=19 \
     CPPCHECK_VERSION=2.14.0 \
     CXX=clang++ \
     CC=clang \

--- a/entrypoint_cpp.sh
+++ b/entrypoint_cpp.sh
@@ -67,16 +67,16 @@ else
         cat cppcheck_*.txt > cppcheck.txt
 
         # Excludes for clang-tidy are handled in python script
-        debug_print "Running run-clang-tidy-18 $CLANG_TIDY_ARGS -p $(pwd) $files_to_check >>clang_tidy.txt 2>&1"
-        eval run-clang-tidy-18 "$CLANG_TIDY_ARGS" -p "$(pwd)" "$files_to_check" >clang_tidy.txt 2>&1 || true
+        debug_print "Running run-clang-tidy-19 $CLANG_TIDY_ARGS -p $(pwd) $files_to_check >>clang_tidy.txt 2>&1"
+        eval run-clang-tidy-19 "$CLANG_TIDY_ARGS" -p "$(pwd)" "$files_to_check" >clang_tidy.txt 2>&1 || true
 
     else
         # Excludes for clang-tidy are handled in python script
         debug_print "Running cppcheck -j $num_proc $files_to_check $CPPCHECK_ARGS --output-file=cppcheck.txt ..."
         eval cppcheck -j "$num_proc" "$files_to_check" "$CPPCHECK_ARGS" --output-file=cppcheck.txt || true
 
-        debug_print "Running run-clang-tidy-18 $CLANG_TIDY_ARGS $files_to_check >>clang_tidy.txt 2>&1"
-        eval run-clang-tidy-18 "$CLANG_TIDY_ARGS" "$files_to_check" >clang_tidy.txt 2>&1 || true
+        debug_print "Running run-clang-tidy-19 $CLANG_TIDY_ARGS $files_to_check >>clang_tidy.txt 2>&1"
+        eval run-clang-tidy-19 "$CLANG_TIDY_ARGS" "$files_to_check" >clang_tidy.txt 2>&1 || true
     fi
 
     cd /

--- a/llvm.sh
+++ b/llvm.sh
@@ -27,12 +27,12 @@ BASE_URL="http://apt.llvm.org"
 needed_binaries=(lsb_release wget add-apt-repository gpg)
 missing_binaries=()
 for binary in "${needed_binaries[@]}"; do
-    if ! which "$binary" &>/dev/null ; then
-        missing_binaries+=("$binary")
+    if ! which $binary &>/dev/null ; then
+        missing_binaries+=($binary)
     fi
 done
 if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
-    echo "You are missing some tools this script requires: " "${missing_binaries[@]}"
+    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
     echo "(hint: apt install lsb-release wget software-properties-common gnupg)"
     exit 4
 fi
@@ -40,6 +40,7 @@ fi
 # Set default values for commandline arguments
 # We default to the current stable branch of LLVM
 LLVM_VERSION=$CURRENT_LLVM_STABLE
+ALL=0
 DISTRO=$(lsb_release -is)
 VERSION=$(lsb_release -sr)
 UBUNTU_CODENAME=""
@@ -76,11 +77,15 @@ esac
 if [ "$#" -ge 1 ] && [ "${1::1}" != "-" ]; then
     if [ "$1" != "all" ]; then
         LLVM_VERSION=$1
+    else
+        # special case for ./llvm.sh all
+        ALL=1
     fi
     OPTIND=2
     if [ "$#" -ge 2 ]; then
       if [ "$2" == "all" ]; then
           # Install all packages
+          ALL=1
           OPTIND=3
       fi
     fi
@@ -124,7 +129,9 @@ LLVM_VERSION_PATTERNS[15]="-15"
 LLVM_VERSION_PATTERNS[16]="-16"
 LLVM_VERSION_PATTERNS[17]="-17"
 LLVM_VERSION_PATTERNS[18]="-18"
-LLVM_VERSION_PATTERNS[19]=""
+LLVM_VERSION_PATTERNS[19]="-19"
+LLVM_VERSION_PATTERNS[20]="-20"
+LLVM_VERSION_PATTERNS[21]=""
 
 if [ ! ${LLVM_VERSION_PATTERNS[$LLVM_VERSION]+_} ]; then
     echo "This script does not support LLVM version $LLVM_VERSION"
@@ -138,7 +145,7 @@ if [[ -n "${CODENAME}" ]]; then
     REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
 
     # check if the repository exists for the distro and version
-    if ! wget -q --method=HEAD "${BASE_URL}/${CODENAME}" &> /dev/null; then
+    if ! wget -q --method=HEAD ${BASE_URL}/${CODENAME} &> /dev/null; then
         if [[ -n "${CODENAME_FROM_ARGUMENTS}" ]]; then
             echo "Specified codename '${CODENAME}' is not supported by this script."
         else
@@ -159,9 +166,23 @@ fi
 # shellcheck disable=SC2006
 if [[ -z "`apt-key list 2> /dev/null | grep -i llvm`" ]]; then
     # Delete the key in the old format
-    apt-key del AF4F7421
+    apt-key del AF4F7421 || true
 fi
+if [[ "${VERSION_CODENAME}" == "bookworm" ]]; then
+    # add it twice to workaround:
+    # https://github.com/llvm/llvm-project/issues/62475
+    add-apt-repository -y "${REPO_NAME}"
+fi
+
 add-apt-repository -y "${REPO_NAME}"
 apt-get update
-PKG="clang-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION clang-tidy-$LLVM_VERSION"
-apt-get install -y "$PKG"
+PKG="clang-$LLVM_VERSION lldb-$LLVM_VERSION lld-$LLVM_VERSION clangd-$LLVM_VERSION clang-tidy-$LLVM_VERSION"
+if [[ $ALL -eq 1 ]]; then
+    # same as in test-install.sh
+    # No worries if we have dups
+    PKG="$PKG clang-format-$LLVM_VERSION clang-tools-$LLVM_VERSION llvm-$LLVM_VERSION-dev llvm-$LLVM_VERSION-tools libomp-$LLVM_VERSION-dev libc++-$LLVM_VERSION-dev libc++abi-$LLVM_VERSION-dev libclang-common-$LLVM_VERSION-dev libclang-$LLVM_VERSION-dev libclang-cpp$LLVM_VERSION-dev libunwind-$LLVM_VERSION-dev"
+    if test $LLVM_VERSION -gt 14; then
+        PKG="$PKG libclang-rt-$LLVM_VERSION-dev libpolly-$LLVM_VERSION-dev"
+    fi
+fi
+apt-get install -y $PKG

--- a/llvm.sh
+++ b/llvm.sh
@@ -27,12 +27,12 @@ BASE_URL="http://apt.llvm.org"
 needed_binaries=(lsb_release wget add-apt-repository gpg)
 missing_binaries=()
 for binary in "${needed_binaries[@]}"; do
-    if ! which $binary &>/dev/null ; then
-        missing_binaries+=($binary)
+    if ! which "$binary" &>/dev/null ; then
+        missing_binaries+=("$binary")
     fi
 done
 if [[ ${#missing_binaries[@]} -gt 0 ]] ; then
-    echo "You are missing some tools this script requires: ${missing_binaries[@]}"
+    echo "You are missing some tools this script requires: " "${missing_binaries[@]}"
     echo "(hint: apt install lsb-release wget software-properties-common gnupg)"
     exit 4
 fi
@@ -145,7 +145,7 @@ if [[ -n "${CODENAME}" ]]; then
     REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
 
     # check if the repository exists for the distro and version
-    if ! wget -q --method=HEAD ${BASE_URL}/${CODENAME} &> /dev/null; then
+    if ! wget -q --method=HEAD "${BASE_URL}/${CODENAME}" &> /dev/null; then
         if [[ -n "${CODENAME_FROM_ARGUMENTS}" ]]; then
             echo "Specified codename '${CODENAME}' is not supported by this script."
         else
@@ -181,8 +181,8 @@ if [[ $ALL -eq 1 ]]; then
     # same as in test-install.sh
     # No worries if we have dups
     PKG="$PKG clang-format-$LLVM_VERSION clang-tools-$LLVM_VERSION llvm-$LLVM_VERSION-dev llvm-$LLVM_VERSION-tools libomp-$LLVM_VERSION-dev libc++-$LLVM_VERSION-dev libc++abi-$LLVM_VERSION-dev libclang-common-$LLVM_VERSION-dev libclang-$LLVM_VERSION-dev libclang-cpp$LLVM_VERSION-dev libunwind-$LLVM_VERSION-dev"
-    if test $LLVM_VERSION -gt 14; then
+    if test "$LLVM_VERSION" -gt 14; then
         PKG="$PKG libclang-rt-$LLVM_VERSION-dev libpolly-$LLVM_VERSION-dev"
     fi
 fi
-apt-get install -y $PKG
+apt-get install -y "$PKG"


### PR DESCRIPTION
This PR does not address the issue in #124, but it updates the Action to use Clang 19.
Some of my changes are fairly opinionated and I wouldn't want you to take them as they are (unless they seem ok to you); you can check out the corresponding commits for some additional information.
Most of the static_analysis.dockerfile changes are based on my research about dockerfiles (since I'm relatively new to them) and helped me to understand, speed up, and follow the build process.
I have confirmed that these changes work [here](https://github.com/eljonny/TestCPP/actions/runs/13404334142/job/37441378906) in my first run with the code from this branch in [a pre-release version of the marketplace action I published](https://github.com/marketplace/actions/static-analysis-for-c-clang-19-python-project), which uses a docker image built with the updated static_analysis.dockerfile [here](https://hub.docker.com/r/jhyry9docks/static_analysis).
I really didn't have to change very much, but CMake takes a long time to compile so it took a bit to be able to really test it for real with my [personal project](https://github.com/eljonny/TestCPP), in which I'm using your Action for C++ analysis with clang-tidy and cppcheck.

I don't know how to do a PR to a new branch on your repo that doesn't exist yet, as I'm not sure these changes should go into master, but it was the only option.