### PR TITLE
[#128]: Use prefix when working with python files

### DIFF
--- a/src/static_analysis_python.py
+++ b/src/static_analysis_python.py
@@ -104,7 +104,7 @@ def create_comment_for_output(tool_output, files_changed_in_pr, output_to_consol
             )
 
             new_line = utils.generate_output(
-                False, ("", file_path), file_line_start, file_line_end, description
+                False, (utils.WORK_DIR, file_path), file_line_start, file_line_end, description
             )
 
             if utils.check_for_char_limit(new_line):


### PR DESCRIPTION
Fixes #128 